### PR TITLE
Fix generated URLs using HTTP instead of HTTPS

### DIFF
--- a/script.js
+++ b/script.js
@@ -298,7 +298,7 @@ document.addEventListener('DOMContentLoaded', function() {
     // Generate the URL based on the form inputs
     function generateUrl() {
         // Base URL for arXiv API
-        const baseUrl = 'http://export.arxiv.org/api/query';
+        const baseUrl = 'https://export.arxiv.org/api/query';
         
         // Build query from the entire structure
         const searchQuery = buildQueryFromGroup(searchTermsContainer);


### PR DESCRIPTION
Update the base URL in generateUrl() function to use https:// instead of http:// for improved security and modern web standards.